### PR TITLE
Quick fix for the reset button

### DIFF
--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -4,12 +4,13 @@ import logger from "logger";
 import { PlayerFullNameParser } from "player-parser";
 import { serializePlayers } from "utils";
 
-let gameManager: IGameManager;
+const gameManager: IGameManager = new GameManager();
+const logParser = new LogParser(gameManager.onLogsChanged, gameManager.onPlayerShortNamesFound);
+const playerFullNameParser = new PlayerFullNameParser(gameManager.onPlayerFullNamesFound);
 
 function recreateGameTracker() {
-	gameManager = new GameManager();
-	new PlayerFullNameParser(gameManager.onPlayerFullNamesFound);
-	new LogParser(gameManager.onLogsChanged, gameManager.onPlayerShortNamesFound);
+	logParser?.reset();
+	playerFullNameParser.reset();
 }
 
 // create initial instance of the game tracker

--- a/src/player-parser/playerFullNameParser.ts
+++ b/src/player-parser/playerFullNameParser.ts
@@ -1,5 +1,6 @@
 import { DominionPlayerFullName } from "@types";
 import { documentObserver } from "observers";
+import { doNotThrow } from "utils";
 import { getPlayerNamesFromDocument } from "./playerParserHelper";
 
 export class PlayerFullNameParser {
@@ -13,6 +14,25 @@ export class PlayerFullNameParser {
 			// containers already exists, use straight away
 			this.updatePlayers(getPlayerNamesFromDocument());
 		}
+	}
+
+	private initListeners() {
+		if (getPlayerNamesFromDocument().length === 0) {
+			// player containers do not exist yet, watch DOM and wait for them to exist
+			this.listenForLogContainerCreation();
+		} else {
+			// containers already exists, use straight away
+			this.updatePlayers(getPlayerNamesFromDocument());
+		}
+	}
+
+	public reset(): void {
+		doNotThrow(() => this.unsubscribeFromDocumentChanges());
+
+		this._players = [];
+		this.observerId = `player-fullname-parser ${Math.random()}`;
+
+		this.initListeners();
 	}
 
 	/** Public getter for the player names */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,14 @@
+import logger from "logger";
+
+export function doNotThrow<T>(fn: (...args : unknown[]) => T): T | undefined  {
+	try {
+		return fn();
+	} catch (e) {
+		logger.error(e);
+		return undefined;
+	}
+}
+
 export * from "./actionHelper";
 export * from "./cardDictionary";
 export * from "./messageSerializer";


### PR DESCRIPTION
## What
Fix the reset button

## What was wrong
Hitting reset game isn't unsubscribing the old trackers and any communication between the content scripts and the popup is using the old trackers' data.
Simply newing up new versions of the log and playerName parsers isn't working. It's capturing the instance of the logparser inside the `chrome.runtime.onMessage.addListener` closure and I can't figure out why.

## How
Ignore the closure problem for now and just reset the data trackers manually