### PR TITLE
quick fix bot shortnames

### DIFF
--- a/src/log-parser/logHelper.test.ts
+++ b/src/log-parser/logHelper.test.ts
@@ -27,74 +27,98 @@ describe("Log helper tests", () => {
 		expect(isValidLogString("C gains a Silver from trash.")).toBeTruthy();
 	});
 
-	test("Successfully converts log strings to dominion logs", () => {
-		expect(convertLogStringToLog("L buys and gains an Ambassador.")).toEqual({
-			playerName: "L",
-			action: DominionAction.Buys_And_Gains,
-			cardStack: [
-				{
-					type: DominionSubjectType.Card,
-					card: "Ambassador",
-					amount: 1,
-				},
-			],
+	describe("Successfully converts log strings to dominion logs", () => {
+		test("L buys and gains an Ambassador.", () => {
+			expect(convertLogStringToLog("L buys and gains an Ambassador.")).toEqual({
+				playerName: "L",
+				action: DominionAction.Buys_And_Gains,
+				cardStack: [
+					{
+						type: DominionSubjectType.Card,
+						card: "Ambassador",
+						amount: 1,
+					},
+				],
+			});
 		});
 
-		expect(convertLogStringToLog("C gains a Noble Brigand.")).toEqual({
-			playerName: "C",
-			action: DominionAction.Gains,
-			cardStack: [
-				{
-					type: DominionSubjectType.Card,
-					card: "Noble Brigand",
-					amount: 1,
-				},
-			],
+		test("Lord R buys and gains an Ambassador.", () => {
+			expect(
+				convertLogStringToLog("Lord R buys and gains an Ambassador.")
+			).toEqual({
+				playerName: "Lord R",
+				action: DominionAction.Buys_And_Gains,
+				cardStack: [
+					{
+						type: DominionSubjectType.Card,
+						card: "Ambassador",
+						amount: 1,
+					},
+				],
+			});
 		});
 
-		expect(
-			convertLogStringToLog("Turtles gains a Silver and a Copper from trash.")
-		).toEqual({
-			playerName: "Turtles",
-			action: DominionAction.Gains,
-			cardStack: [
-				{
-					type: DominionSubjectType.Card,
-					card: "Silver",
-					amount: 1,
-				},
-				{
-					type: DominionSubjectType.Card,
-					card: "Copper",
-					amount: 1,
-				},
-			],
+		test("C gains a Noble Brigand.", () => {
+			expect(convertLogStringToLog("C gains a Noble Brigand.")).toEqual({
+				playerName: "C",
+				action: DominionAction.Gains,
+				cardStack: [
+					{
+						type: DominionSubjectType.Card,
+						card: "Noble Brigand",
+						amount: 1,
+					},
+				],
+			});
 		});
 
-		expect(
-			convertLogStringToLog(
-				"NextYear starts with a Death Cart, 13 Rats and 2020 Doctors."
-			)
-		).toEqual({
-			playerName: "NextYear",
-			action: DominionAction.Starts_With,
-			cardStack: [
-				{
-					type: DominionSubjectType.Card,
-					card: "Death Cart",
-					amount: 1,
-				},
-				{
-					type: DominionSubjectType.Card,
-					card: "Rats",
-					amount: 13,
-				},
-				{
-					type: DominionSubjectType.Card,
-					card: "Doctor",
-					amount: 2020,
-				},
-			],
+		test("Turtles gains a Silver and a Copper from trash.", () => {
+			expect(
+				convertLogStringToLog("Turtles gains a Silver and a Copper from trash.")
+			).toEqual({
+				playerName: "Turtles",
+				action: DominionAction.Gains,
+				cardStack: [
+					{
+						type: DominionSubjectType.Card,
+						card: "Silver",
+						amount: 1,
+					},
+					{
+						type: DominionSubjectType.Card,
+						card: "Copper",
+						amount: 1,
+					},
+				],
+			});
+		});
+
+		test("NextYear starts with a Death Cart, 13 Rats and 2020 Doctors.", () => {
+			expect(
+				convertLogStringToLog(
+					"NextYear starts with a Death Cart, 13 Rats and 2020 Doctors."
+				)
+			).toEqual({
+				playerName: "NextYear",
+				action: DominionAction.Starts_With,
+				cardStack: [
+					{
+						type: DominionSubjectType.Card,
+						card: "Death Cart",
+						amount: 1,
+					},
+					{
+						type: DominionSubjectType.Card,
+						card: "Rats",
+						amount: 13,
+					},
+					{
+						type: DominionSubjectType.Card,
+						card: "Doctor",
+						amount: 2020,
+					},
+				],
+			});
 		});
 	});
 

--- a/src/log-parser/logHelpers.ts
+++ b/src/log-parser/logHelpers.ts
@@ -60,8 +60,14 @@ export const isValidLogString = (logString: string): boolean => {
  */
 export const convertLogStringToLog = (logAsString: string): DominionCommand => {
 	// Extract player - Be trivial about this for now and assume
-	// players dont have spaces in their name.
-	const playerName = logAsString.split(/\s/gm)[0];
+	// players dont have spaces in their name, except do an extra
+	// quick check for the bots (Lord R and Lord V).
+	let playerName = logAsString.split(/\s/gm)[0];
+	if (playerName === "Lord") {
+		const botShortname = logAsString.split(/\s/gm)[1];
+		if (botShortname === "R" || botShortname === "V")
+			playerName += " " + logAsString.split(/\s/gm)[1];
+	}
 
 	//slice player name from log string
 	const logWithoutPlayerName = logAsString.slice(playerName.length).trim()
@@ -87,8 +93,8 @@ export const getPlayerShortNamesFromContainer = (logContainer: HTMLElement): Dom
 		.map(log => convertLogAsHTMLElementToString(log as HTMLElement))
 		// filter logs to remove only the logs we care about. For simplicity use the "starts with" log lines
 		.filter(log => log.includes("starts with"))
-		// extract player names
-		.map(log => log.trim().split(/\s/gm)[0]);
+		// extract player names, assume it is everything before ' starts with ...'
+		.map(log => log.trim().split(/\sstarts with/gm)[0].trim());
 
 	// Quickly throw into a set to remove duplicates and convert back to array cause I am writing this fast
 	return Array.from(new Set(playersNames));


### PR DESCRIPTION
## What
Quickly fix that botnames weren't being picked up correctly

## Why
We trivially assume shortnames do not have spaces... but in the case of bots they do.
When playing with Lord Rattington and Lord Voldebot in a game their shortnames are:
* Lord V
* Lord R

## Fix
1. In the log parsing just add a quick check for if its Lord R or Lord V
2. In the shortname parser grab the whole name by getting everything before the ` starts with`