### PR TITLE
Add game duration to game manager and player upload details

### DIFF
--- a/src/@types/player.ts
+++ b/src/@types/player.ts
@@ -11,4 +11,5 @@ export interface DominionPlayer {
 	turns?: number;
 	gameNumber?: string;
 	date?: Date;
+	gameDuration?: number;
 }

--- a/src/game-manager/endOfGameHelper.ts
+++ b/src/game-manager/endOfGameHelper.ts
@@ -9,10 +9,7 @@ export const isEndOfGameScreen = () : boolean => {
 
 //TODO: Write a test
 //adds scores to players or returns false if not at end-of-game screen.
-export const addEndOfGameScoresToPlayers = (scoreContainer: HTMLElement, players: DominionPlayer[], gameNumber: string) : boolean => {
-	//check if we are on the end-screen
-	if (!isEndOfGameScreen()) return false
-
+export const addEndOfGameScoresToPlayers = (scoreContainer: HTMLElement, players: DominionPlayer[], gameNumber: string, gameDuration: number | undefined) : boolean => {
 	//turn the data into an array, remove the header information
 	let scoreArray: string[] =  scoreContainer.innerText.split("\n").slice(6)
 	const date: Date = new Date()
@@ -33,6 +30,8 @@ export const addEndOfGameScoresToPlayers = (scoreContainer: HTMLElement, players
 				player.turns = turns
 				player.gameNumber = gameNumber
 				player.date = date
+				// This won't be known if a game was joined part-way through.
+				player.gameDuration = gameDuration
 				break
 			}
 		}


### PR DESCRIPTION
## What
Add game duration
* Record game start in the game manager
  * This is decided when logs that only contain "starts with" are present
  * Save to local storage and use gameNumber as key so it can be retrieved on refreshes
* Get game end time by adding a watcher to look for the end of game screen
* Output the game time in the logs and add to player object to be uploaded

## How Tested
Started and resigned a couple games in a row:
![image](https://user-images.githubusercontent.com/2684369/109439317-b28bac80-79e2-11eb-8c28-e32a371de8c5.png)
